### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/aws/serverlessImageGallery.yaml
+++ b/aws/serverlessImageGallery.yaml
@@ -170,7 +170,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: lambda.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: 
         Bucket: !Ref BucketName
         Key: upload/UploadS3.zip
@@ -204,7 +204,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Policies:
         - Version: '2012-10-17'
           Statement:
@@ -247,7 +247,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Policies:
         - Version: '2012-10-17'
           Statement:

--- a/blog/cf/serverlessImageGallery.yaml
+++ b/blog/cf/serverlessImageGallery.yaml
@@ -153,7 +153,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       InlineCode: 
         "const AWS = require('aws-sdk');\n
           const s3 = new AWS.S3({apiVersion: '2006-03-01'});\n
@@ -222,7 +222,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Policies:
         - Version: '2012-10-17'
           Statement:
@@ -319,7 +319,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Policies:
         - Version: '2012-10-17'
           Statement:


### PR DESCRIPTION
CloudFormation templates in global-serverless-image-gallery have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.